### PR TITLE
fix: don't delete permissions on requests for static resources

### DIFF
--- a/superset_config.py
+++ b/superset_config.py
@@ -313,7 +313,7 @@ def app_mutator(app):
 
     @app.before_request
     def before_request():  # pylint: disable=unused-variable
-        if g.user is not None and g.user.is_authenticated:
+        if g.user is not None and g.user.is_authenticated and not request.path.startswith('/static/'):
             role_name = base_role_names[request.host.split(".")[0]]
             if role_name == "Public":
                 apply_public_role_permissions(security_manager, g.user, f"{g.user.username}-Role")


### PR DESCRIPTION
Requests for static resources in Superset don't have anything added to them by the proxy, e.g.
https://github.com/uktrade/data-workspace-frontend/blob/19bfcefbf82c1135718e46e07c67bdd4524d983f/dataworkspace/proxy.py#L234, so I suspect permissions for dashboards were getting "correctly" deleted, causing permission errors to surface to the users.

This addresses this by not making any changes to permissions for static resources.