### PR TITLE
build(deps): bump flask-jwt-extended and remove usage of flask's json

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -120,7 +120,7 @@ flask-caching==2.1.0
     # via apache-superset
 flask-compress==1.13
     # via apache-superset
-flask-jwt-extended==4.4.2
+flask-jwt-extended==4.6.0
     # via flask-appbuilder
 flask-limiter==3.3.0
     # via flask-appbuilder

--- a/superset_config.py
+++ b/superset_config.py
@@ -1,5 +1,6 @@
 import contextlib
 import decimal
+import json
 import logging
 import os
 
@@ -14,7 +15,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Semi-magical request-local proxy objects
-from flask import g, json, make_response, redirect, request, session
+from flask import g, make_response, redirect, request, session
 
 from superset import db, security_manager
 from superset.security import SupersetSecurityManager


### PR DESCRIPTION
This is to avoid errors looking for flask's json which no longer exists