### PR TITLE
fix: (re)enabled subqueries

### DIFF
--- a/superset_config.py
+++ b/superset_config.py
@@ -345,7 +345,10 @@ CUSTOM_SECURITY_MANAGER = DataWorkspaceSecurityManager
 AUTH_TYPE = AUTH_REMOTE_USER
 ADDITIONAL_MIDDLEWARE = [lambda app: ProxyFix(app, x_proto=1)]
 
-FEATURE_FLAGS = {"SQLLAB_BACKEND_PERSISTENCE": True}
+FEATURE_FLAGS = {
+    "SQLLAB_BACKEND_PERSISTENCE": True,
+    "ALLOW_ADHOC_SUBQUERY": True,
+}
 
 if os.environ.get("SENTRY_DSN") is not None:
     # This doesn't go over the public internet, so it's fine to not use HTTPS


### PR DESCRIPTION
This enables adhoc subqueries by setting the ALLOW_ADHOC_SUBQUERY to True.

We seem to have been depending on adhoc subqueries for a while, for some reason only the recent upgrade from 4.0.2 to 4.1.0 has apparently disabled their use. This is in spite of the ALLOW_ADHOC_SUBQUERY being added to Superset, with a default of False, back in 3.0.0. We have no explanation for this.

The ALLOW_ADHOC_SUBQUERY flag exists and has a default of False apparently for security reasons. We can't think of why this would be - perhaps in a slightly different permissions setup, but in our setup is focused around all the permissions that a single database user/connection has, so I suspect it's fine - we expect full use of PostgreSQL features once a connection is made by a given database user.