### PR TITLE
fix: enable adhoc subquery feature flag

### DIFF
--- a/superset_config.py
+++ b/superset_config.py
@@ -345,7 +345,7 @@ CUSTOM_SECURITY_MANAGER = DataWorkspaceSecurityManager
 AUTH_TYPE = AUTH_REMOTE_USER
 ADDITIONAL_MIDDLEWARE = [lambda app: ProxyFix(app, x_proto=1)]
 
-FEATURE_FLAGS = {"SQLLAB_BACKEND_PERSISTENCE": True}
+FEATURE_FLAGS = {"SQLLAB_BACKEND_PERSISTENCE": True, "ALLOW_ADHOC_SUBQUERY": True}
 
 if os.environ.get("SENTRY_DSN") is not None:
     # This doesn't go over the public internet, so it's fine to not use HTTPS


### PR DESCRIPTION
## What

Enabling adhoc subquery feature flag to avoid the error message described here: https://github.com/apache/superset/issues/25072.

## Why

Some of our existing dashboards (e.g., [Pipelines Dashboard](https://data.trade.gov.uk/visualisations/link/63a2a127-ea8d-473b-9adc-7f079e63eb5a)) rely on subqueries in custom SQL and are showing the following error message:

"Custom SQL fields cannot contain sub-queries."

